### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -660,7 +660,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token (sanitized): %s", sanitizeToken(authz))
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)
@@ -680,6 +680,13 @@ func authnMiddleware(next http.Handler) http.Handler {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 
 	})
+}
+
+func sanitizeToken(token string) string {
+	if len(token) > 10 {
+		return token[:10] + "..." // Log only the first 10 characters for debugging
+	}
+	return token
 }
 
 func main() {


### PR DESCRIPTION
Potential fix for [https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/4](https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/4)

To fix the issue, we should avoid logging the full `Authorization` header or bearer token. Instead, we can log a sanitized or partial version of the token (e.g., the first few characters) to aid debugging without exposing the full sensitive information. Alternatively, we can omit logging the token entirely if it is not necessary for debugging or operational purposes.

The fix involves modifying the logging statement on line 663 to either exclude the token or log only a sanitized version. This ensures that sensitive information is not exposed in the logs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
