### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
+++ b/storage-service/src/main/java/com/github/advancedsecurity/storageservice/WebSecurityConfig.java
@@ -44,7 +44,7 @@ public class WebSecurityConfig extends WebSecurityConfigurerAdapter {
 		BearerAuthenticationFilter filter = new BearerAuthenticationFilter(authenticationManager(), this.antPattern);
 		filter.setAuthenticationSuccessHandler(jwtAuthenticationSuccessHandler);
 		http.cors().and()
-			 .csrf().disable()
+			 .csrf().and()
 			 .authorizeRequests().antMatchers(this.antPattern).authenticated().and()
 			 .addFilterBefore(filter, UsernamePasswordAuthenticationFilter.class)
 			 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS);


### PR DESCRIPTION
Potential fix for [https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/5](https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/5)

To fix the issue, CSRF protection should be re-enabled in the `configure(HttpSecurity http)` method. If there are specific endpoints or use cases where CSRF protection is not required, those exceptions should be explicitly defined using Spring Security's configuration options.

**Steps to fix:**
1. Remove the `http.csrf().disable()` line.
2. Ensure CSRF protection is enabled by default.
3. If necessary, configure CSRF protection to exclude specific endpoints or methods using `csrf().ignoringAntMatchers()` or similar configurations.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
