### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -641,7 +641,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			log.Printf("AuthN: Received bearer token")
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {


### PR DESCRIPTION
Potential fix for [https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/3](https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/3)

To fix the issue, we should avoid logging the sensitive `tokenString` entirely. Instead, we can log a generic message indicating that a bearer token was received, without including the token itself. This ensures that sensitive information is not exposed in the logs while still providing useful debugging information.

The changes will involve:
1. Replacing the logging statement on line 644 to remove the `tokenString` and replace it with a generic message.
2. Ensuring that no other sensitive information is logged in the same context.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
