### PR TITLE
Potential fix for code scanning alert no. 2: Database query built from user-controlled sources

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -197,13 +197,13 @@ func (g *Gallery) Create(profile *OctoProfile) error {
 func (g Gallery) Update(profile *OctoProfile) error {
 	db := GetDb()
 
-	stmt, err := db.Prepare(fmt.Sprintf("UPDATE gallery SET title = '%s', description = '%s' WHERE id = %d and login = '%s'", g.Title, g.Description, g.ID, profile.Login))
+	stmt, err := db.Prepare("UPDATE gallery SET title = ?, description = ? WHERE id = ? and login = ?")
 	if err != nil {
 		return err
 	}
 	defer stmt.Close()
 
-	r , err := stmt.Exec()
+	r , err := stmt.Exec(g.Title, g.Description, g.ID, profile.Login)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Potential fix for [https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/2](https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/2)

To fix the issue, the SQL query should be constructed using prepared statements with placeholders instead of `fmt.Sprintf`. This ensures that user-controlled data is safely embedded into the query, preventing SQL injection.

**Steps to fix:**
1. Replace the `fmt.Sprintf` query construction with a prepared statement using placeholders (`?`).
2. Pass the user-controlled values (`g.Title`, `g.Description`, `g.ID`, and `profile.Login`) as arguments to the `stmt.Exec` method.
3. Ensure no functionality changes occur, and the query logic remains the same.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
