### PR TITLE
Potential fix for code scanning alert no. 4: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -660,7 +660,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token %s", obfuscateToken(authz))
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)
@@ -680,6 +680,13 @@ func authnMiddleware(next http.Handler) http.Handler {
 		http.Error(w, "Forbidden", http.StatusForbidden)
 
 	})
+}
+
+func obfuscateToken(token string) string {
+	if len(token) > 10 {
+		return token[:10] + "..."
+	}
+	return token
 }
 
 func main() {


### PR DESCRIPTION
Potential fix for [https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/4](https://github.com/org-contoso/ghas-bootcamp/security/code-scanning/4)

To fix the issue, we should avoid logging the full `Authorization` header or its bearer token. Instead, we can log a sanitized or obfuscated version of the token, such as only the first few characters followed by an ellipsis. This approach ensures that sensitive information is not exposed in the logs while still providing enough context for debugging purposes.

The changes will involve:
1. Modifying the logging statement on line 663 to obfuscate the `authz` value.
2. Ensuring that no other sensitive information is logged in plain text.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
